### PR TITLE
Update to 0.15

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,11 +1,11 @@
 {
   "name": "BridgeRailway",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "title": "Bridge Railway",
   "author": "MrP123",
   "contact": "https://github.com/MrP123",
   "homepage": "https://github.com/MrP123/BridgeRailway",
   "description": "A mod that adds rails which can be placed on water",
-	"factorio_version":"0.14",
+  "factorio_version":"0.15",
   "dependencies": ["base"]
 }

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -1,25 +1,25 @@
 [entity-name]
-bridge-straight-rail = Bridge Straight Rail
-bridge-curved-rail = Bridge Curved Rail
-bridge-rail-signal = Bridge Rail Signal
-bridge-rail-chain-signal = Bridge Rail Chain Signal
+bridge-straight-rail=Bridge Straight Rail
+bridge-curved-rail=Bridge Curved Rail
+bridge-rail-signal=Bridge Rail Signal
+bridge-rail-chain-signal=Bridge Rail Chain Signal
 
 [item-name]
-bridge-straight-rail = Bridge Straight Rail
-bridge-curved-rail = Bridge Curved Rail
-bridge-rail-signal = Bridge Rail Signal
-bridge-rail-chain-signal = Bridge Rail Chain Signal
+bridge-straight-rail=Bridge Straight Rail
+bridge-curved-rail=Bridge Curved Rail
+bridge-rail-signal=Bridge Rail Signal
+bridge-rail-chain-signal=Bridge Rail Chain Signal
 
 [item-description]
-bridge-straight-rail = can be placed on water
-bridge-curved-rail = can be placed on water
-bridge-rail-singal = can be placed on water
-bridge-rail-chain-signal = can be placed on water
+bridge-straight-rail=can be placed on water
+bridge-curved-rail=can be placed on water
+bridge-rail-singal=can be placed on water
+bridge-rail-chain-signal=can be placed on water
 
 [technology-name]
-bridge-railway = Bridge Railway
-bridge-railway-signals = Bridge Railway Signals
+bridge-railway=Bridge Railway
+bridge-railway-signals=Bridge Railway Signals
 
 [technology-description]
-bridge-railway = A new type of rails that can be placed on water
-bridge-rail-signals = You can now place rail signals on water!
+bridge-railway=A new type of rails that can be placed on water
+bridge-rail-signals=You can now place rail signals on water!


### PR DESCRIPTION
Updated version in info to be appropriate
fixed locale/en/locale.cfg - there was extra spaces around '=' which caused factorio to say 'bad key'